### PR TITLE
FEATURE: 🚢  Add pagination

### DIFF
--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -141,9 +141,9 @@ abstract class GetProductCatalogTestCase : TestCase() {
     val tree = mapper.readTree(actual)
     assertEquals(0, tree["page"].asInt())
     assertEquals(30, tree["totalElements"].asInt())
-    assertEquals(6, tree["totalPages"].asInt())
-    assertEquals(10, tree["size"].asInt())
-    assertEquals(10, tree["content"].size())
+    assertEquals(2, tree["totalPages"].asInt())
+    assertEquals(20, tree["size"].asInt())
+    assertEquals(20, tree["products"].size())
   }
 
   @Test
@@ -161,6 +161,6 @@ abstract class GetProductCatalogTestCase : TestCase() {
     assertEquals(5, tree["size"].asInt())
     assertEquals(30, tree["totalElements"].asInt())
     assertEquals(6, tree["totalPages"].asInt())
-    assertEquals(5, tree["content"].size())
+    assertEquals(5, tree["products"].size())
   }
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -55,7 +55,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
 
     val actualJson = given()
         .contentType("application/json")
-        .get("/products")
+        .get("/products?page=0&size=30")
         .then()
         .statusCode(200)
         .extract()
@@ -120,7 +120,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
   ) {
     given()
         .contentType("application/json")
-        .get("/products?sortField=$sortField&sortOrder=$sortOrder")
+        .get("/products?sortField=$sortField&sortOrder=$sortOrder&size=30")
         .then()
         .statusCode(200)
         .body("products", hasSize<Any>(30))

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -49,7 +49,11 @@ abstract class GetProductCatalogTestCase : TestCase() {
         {"sku":"SKU0028","description":"Kids' Educational Tablet Toy","price":"22.00","discountPercentage":"0.00","finalPrice":"22.00","category":"Toys & Games"},
         {"sku":"SKU0029","description":"Mechanical Gaming Keyboard with RGB Lighting","price":"110.00","discountPercentage":"15.00","finalPrice":"93.50","category":"Electronics"},
         {"sku":"SKU0030","description":"Pack of 10 Ballpoint Pens, Blue Ink","price":"7.50","discountPercentage":"0.00","finalPrice":"7.50","category":"Stationery"}
-      ]
+      ],
+      "page":0,
+      "size":30,
+      "totalElements":30,
+      "totalPages":1
     }
     """.trimIndent()
 
@@ -83,7 +87,11 @@ abstract class GetProductCatalogTestCase : TestCase() {
         {"sku":"SKU0022","description":"Wireless Charger Pad for Smartphones","price":"19.00","discountPercentage":"15.00","finalPrice":"16.15","category":"Electronics"},
         {"sku":"SKU0025","description":"Home Security Camera with Night Vision","price":"99.00","discountPercentage":"30.00","finalPrice":"69.30","category":"Electronics"},
         {"sku":"SKU0029","description":"Mechanical Gaming Keyboard with RGB Lighting","price":"110.00","discountPercentage":"15.00","finalPrice":"93.50","category":"Electronics"}
-      ]
+      ],
+      "page":0,
+      "size":20,
+      "totalElements":10,
+      "totalPages":1
     }
     """.trimIndent()
 

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -127,4 +127,40 @@ abstract class GetProductCatalogTestCase : TestCase() {
         .body("products[0].${sortField.lowercase()}", equalTo(first))
         .body("products[-1].${sortField.lowercase()}", equalTo(last))
   }
+
+  @Test
+  fun `should return first page with default size`() {
+    val actual = given()
+        .contentType("application/json")
+        .get("/products")
+        .then()
+        .statusCode(200)
+        .extract()
+        .asString()
+
+    val tree = mapper.readTree(actual)
+    assertEquals(0, tree["page"].asInt())
+    assertEquals(30, tree["totalElements"].asInt())
+    assertEquals(6, tree["totalPages"].asInt())
+    assertEquals(10, tree["size"].asInt())
+    assertEquals(10, tree["content"].size())
+  }
+
+  @Test
+  fun `should return second page with custom size`() {
+    val actual = given()
+        .contentType("application/json")
+        .get("/products?page=1&size=5")
+        .then()
+        .statusCode(200)
+        .extract()
+        .asString()
+
+    val tree = mapper.readTree(actual)
+    assertEquals(1, tree["page"].asInt())
+    assertEquals(5, tree["size"].asInt())
+    assertEquals(30, tree["totalElements"].asInt())
+    assertEquals(6, tree["totalPages"].asInt())
+    assertEquals(5, tree["content"].size())
+  }
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -1,5 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.testcases
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.restassured.module.mockmvc.RestAssuredMockMvc.given
 import org.hamcrest.CoreMatchers.equalTo
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import java.nio.charset.StandardCharsets
 
 abstract class GetProductCatalogTestCase : TestCase() {
 
@@ -15,8 +17,6 @@ abstract class GetProductCatalogTestCase : TestCase() {
 
   @Test
   fun `should return product catalog with proper discounts applied for all products`() {
-    val expectedJson = loadJson("all_products_page0_size30.json")
-
     val actualJson = given()
         .contentType("application/json")
         .get("/products?page=0&size=30")
@@ -25,7 +25,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
         .extract()
         .asString()
 
-    val expectedTree = mapper.readTree(expectedJson)
+    val expectedTree = loadFixture("all_products_page0_size30.json")
     val actualTree = mapper.readTree(actualJson)
 
     assertEquals(expectedTree, actualTree)
@@ -34,8 +34,6 @@ abstract class GetProductCatalogTestCase : TestCase() {
   // TODO: I should add a parameterized test to verify that can filter by any category
   @Test
   fun `should return only electronics items when filtering by category Electronics`() {
-    val expectedJson = loadJson("electronics_default_page.json")
-
     val actualJson = given()
         .contentType("application/json")
         .get("/products?category=ELECTRONICS")
@@ -44,7 +42,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
         .extract()
         .asString()
 
-    val expectedTree = mapper.readTree(expectedJson)
+    val expectedTree = loadFixture("electronics_default_page.json")
     val actualTree = mapper.readTree(actualJson)
 
     assertEquals(expectedTree, actualTree)
@@ -113,10 +111,10 @@ abstract class GetProductCatalogTestCase : TestCase() {
     assertEquals(5, tree["products"].size())
   }
 
-  private fun loadJson(name: String): String =
+  private fun loadFixture(path: String): JsonNode =
       javaClass.classLoader
-          .getResourceAsStream("responses/$name")
-          ?.bufferedReader(Charsets.UTF_8)
-          ?.use { it.readText().trimIndent() }
-        ?: error("Could not load resource responses/$name")
+          .getResourceAsStream("responses/$path")
+          ?.bufferedReader(StandardCharsets.UTF_8)
+          ?.use { mapper.readTree(it) }
+        ?: error("Fixture not found: responses/$path")
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -3,7 +3,6 @@ package com.capitole.capitoleproductcatalogapi.infrastructure.testcases
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.restassured.module.mockmvc.RestAssuredMockMvc.given
-import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -17,47 +16,28 @@ abstract class GetProductCatalogTestCase : TestCase() {
 
   @Test
   fun `should return product catalog with proper discounts applied for all products`() {
-    val actualJson = given()
-        .contentType("application/json")
-        .get("/products?page=0&size=30")
-        .then()
-        .statusCode(200)
-        .extract()
-        .asString()
-
-    val expectedTree = loadFixture("all_products_page0_size30.json")
-    val actualTree = mapper.readTree(actualJson)
-
-    assertEquals(expectedTree, actualTree)
+    val expected = loadFixture("all_products_page0_size30.json")
+    val actual = fetchTree("/products?page=0&size=30")
+    assertEquals(expected, actual)
   }
 
-  // TODO: I should add a parameterized test to verify that can filter by any category
   @Test
   fun `should return only electronics items when filtering by category Electronics`() {
-    val actualJson = given()
-        .contentType("application/json")
-        .get("/products?category=ELECTRONICS")
-        .then()
-        .statusCode(200)
-        .extract()
-        .asString()
-
-    val expectedTree = loadFixture("electronics_default_page.json")
-    val actualTree = mapper.readTree(actualJson)
-
-    assertEquals(expectedTree, actualTree)
+    val expected = loadFixture("electronics_default_page.json")
+    val actual = fetchTree("/products?category=ELECTRONICS")
+    assertEquals(expected, actual)
   }
 
-  @ParameterizedTest(name = "{index} sort by {0} {1}")
+  @ParameterizedTest(name = "`[{index}] sort by {0} {1}`")
   @CsvSource(
-      "PRICE,ASC,7.50,499.00",
-      "PRICE,DESC,499.00,7.50",
-      "SKU,ASC,SKU0001,SKU0030",
-      "SKU,DESC,SKU0030,SKU0001",
-      "DESCRIPTION,ASC,'4K Ultra HD Smart TV, 55 inches','Yoga Mat with Non-Slip Surface'",
-      "DESCRIPTION,DESC,'Yoga Mat with Non-Slip Surface','4K Ultra HD Smart TV, 55 inches'",
-      "CATEGORY,ASC,Accessories,'Toys & Games'",
-      "CATEGORY,DESC,'Toys & Games',Accessories"
+      "PRICE,ASC,         7.50,499.00",
+      "PRICE,DESC,        499.00,7.50",
+      "SKU,ASC,           SKU0001,SKU0030",
+      "SKU,DESC,          SKU0030,SKU0001",
+      "DESCRIPTION,ASC,   '4K Ultra HD Smart TV, 55 inches','Yoga Mat with Non-Slip Surface'",
+      "DESCRIPTION,DESC,  'Yoga Mat with Non-Slip Surface','4K Ultra HD Smart TV, 55 inches'",
+      "CATEGORY,ASC,      Accessories,'Toys & Games'",
+      "CATEGORY,DESC,     'Toys & Games',Accessories"
   )
   fun `should return products sorted correctly`(
     sortField: String,
@@ -65,27 +45,15 @@ abstract class GetProductCatalogTestCase : TestCase() {
     first: String,
     last: String
   ) {
-    given()
-        .contentType("application/json")
-        .get("/products?sortField=$sortField&sortOrder=$sortOrder&size=30")
-        .then()
-        .statusCode(200)
-        .body("products", hasSize<Any>(30))
-        .body("products[0].${sortField.lowercase()}", equalTo(first))
-        .body("products[-1].${sortField.lowercase()}", equalTo(last))
+    val uri = "/products?sortField=$sortField&sortOrder=$sortOrder&size=30"
+    val tree = fetchTree(uri, expectedSize = 30)
+    assertEquals(first, tree["products"][0][sortField.lowercase()].asText())
+    assertEquals(last, tree["products"].last()[sortField.lowercase()].asText())
   }
 
   @Test
   fun `should return first page with default size`() {
-    val actual = given()
-        .contentType("application/json")
-        .get("/products")
-        .then()
-        .statusCode(200)
-        .extract()
-        .asString()
-
-    val tree = mapper.readTree(actual)
+    val tree = fetchTree("/products")
     assertEquals(0, tree["page"].asInt())
     assertEquals(30, tree["totalElements"].asInt())
     assertEquals(2, tree["totalPages"].asInt())
@@ -95,15 +63,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
 
   @Test
   fun `should return second page with custom size`() {
-    val actual = given()
-        .contentType("application/json")
-        .get("/products?page=1&size=5")
-        .then()
-        .statusCode(200)
-        .extract()
-        .asString()
-
-    val tree = mapper.readTree(actual)
+    val tree = fetchTree("/products?page=1&size=5")
     assertEquals(1, tree["page"].asInt())
     assertEquals(5, tree["size"].asInt())
     assertEquals(30, tree["totalElements"].asInt())
@@ -111,10 +71,22 @@ abstract class GetProductCatalogTestCase : TestCase() {
     assertEquals(5, tree["products"].size())
   }
 
-  private fun loadFixture(path: String): JsonNode =
+  private fun fetchTree(uri: String, expectedSize: Int? = null): JsonNode {
+    val response = given()
+        .contentType("application/json")
+        .get(uri)
+        .then()
+        .statusCode(200)
+        .apply { expectedSize?.let { body("products", hasSize<Any>(it)) } }
+        .extract()
+        .asString()
+    return mapper.readTree(response)
+  }
+
+  private fun loadFixture(name: String): JsonNode =
       javaClass.classLoader
-          .getResourceAsStream("responses/$path")
+          .getResourceAsStream("responses/$name")
           ?.bufferedReader(StandardCharsets.UTF_8)
           ?.use { mapper.readTree(it) }
-        ?: error("Fixture not found: responses/$path")
+        ?: error("Fixture not found: responses/$name")
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -1,18 +1,14 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.testcases
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.restassured.module.mockmvc.RestAssuredMockMvc.given
 import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import java.nio.charset.StandardCharsets
 
 abstract class GetProductCatalogTestCase : TestCase() {
-
-  private val mapper = ObjectMapper()
 
   @Test
   fun `should return product catalog with proper discounts applied for all products`() {
@@ -82,11 +78,4 @@ abstract class GetProductCatalogTestCase : TestCase() {
         .asString()
     return mapper.readTree(response)
   }
-
-  private fun loadFixture(name: String): JsonNode =
-      javaClass.classLoader
-          .getResourceAsStream("responses/$name")
-          ?.bufferedReader(StandardCharsets.UTF_8)
-          ?.use { mapper.readTree(it) }
-        ?: error("Fixture not found: responses/$name")
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/GetProductCatalogTestCase.kt
@@ -13,49 +13,9 @@ abstract class GetProductCatalogTestCase : TestCase() {
 
   private val mapper = ObjectMapper()
 
-  // TODO: Improve the readability of the test, move the json to a file
   @Test
   fun `should return product catalog with proper discounts applied for all products`() {
-    val expectedJson = """
-    {
-      "products": [
-        {"sku":"SKU0001","description":"Wireless Mouse with ergonomic design","price":"19.99","discountPercentage":"15.00","finalPrice":"16.99","category":"Electronics"},
-        {"sku":"SKU0002","description":"4K Ultra HD Smart TV, 55 inches","price":"499.00","discountPercentage":"15.00","finalPrice":"424.15","category":"Electronics"},
-        {"sku":"SKU0003","description":"Stainless Steel Water Bottle, 1L","price":"29.50","discountPercentage":"25.00","finalPrice":"22.13","category":"Home & Kitchen"},
-        {"sku":"SKU0004","description":"Cotton T-Shirt, Unisex, Size M","price":"15.00","discountPercentage":"0.00","finalPrice":"15.00","category":"Clothing"},
-        {"sku":"SKU0005","description":"Noise-Cancelling Over-Ear Headphones","price":"120.00","discountPercentage":"30.00","finalPrice":"84.00","category":"Electronics"},
-        {"sku":"SKU0006","description":"USB-C to USB Adapter","price":"9.99","discountPercentage":"15.00","finalPrice":"8.49","category":"Electronics"},
-        {"sku":"SKU0007","description":"Leather Wallet with RFID Protection","price":"75.00","discountPercentage":"0.00","finalPrice":"75.00","category":"Accessories"},
-        {"sku":"SKU0008","description":"Yoga Mat with Non-Slip Surface","price":"35.00","discountPercentage":"0.00","finalPrice":"35.00","category":"Sports"},
-        {"sku":"SKU0009","description":"Smartwatch with Heart Rate Monitor","price":"220.00","discountPercentage":"15.00","finalPrice":"187.00","category":"Electronics"},
-        {"sku":"SKU0010","description":"Ceramic Coffee Mug, 350ml","price":"12.50","discountPercentage":"25.00","finalPrice":"9.38","category":"Home & Kitchen"},
-        {"sku":"SKU0011","description":"Bluetooth Portable Speaker","price":"60.00","discountPercentage":"15.00","finalPrice":"51.00","category":"Electronics"},
-        {"sku":"SKU0012","description":"Backpack with Laptop Compartment","price":"85.00","discountPercentage":"0.00","finalPrice":"85.00","category":"Accessories"},
-        {"sku":"SKU0013","description":"Stainless Steel Cutlery Set, 24 Pieces","price":"18.00","discountPercentage":"25.00","finalPrice":"13.50","category":"Home & Kitchen"},
-        {"sku":"SKU0014","description":"Electric Guitar Starter Pack","price":"250.00","discountPercentage":"0.00","finalPrice":"250.00","category":"Musical Instruments"},
-        {"sku":"SKU0015","description":"Running Shoes, Men's Size 42","price":"42.00","discountPercentage":"30.00","finalPrice":"29.40","category":"Footwear"},
-        {"sku":"SKU0016","description":"Digital Bathroom Scale with Body Fat Analyzer","price":"27.99","discountPercentage":"0.00","finalPrice":"27.99","category":"Home Appliances"},
-        {"sku":"SKU0017","description":"Set of 6 Organic Cotton Socks","price":"14.99","discountPercentage":"0.00","finalPrice":"14.99","category":"Clothing"},
-        {"sku":"SKU0018","description":"DSLR Camera with 18-55mm Lens","price":"300.00","discountPercentage":"15.00","finalPrice":"255.00","category":"Electronics"},
-        {"sku":"SKU0019","description":"Hardcover Notebook, A5, 200 Pages","price":"8.99","discountPercentage":"0.00","finalPrice":"8.99","category":"Stationery"},
-        {"sku":"SKU0020","description":"Microwave Oven, 20L Capacity","price":"65.00","discountPercentage":"0.00","finalPrice":"65.00","category":"Home Appliances"},
-        {"sku":"SKU0021","description":"LED Desk Lamp with Adjustable Brightness","price":"23.50","discountPercentage":"25.00","finalPrice":"17.63","category":"Home & Kitchen"},
-        {"sku":"SKU0022","description":"Wireless Charger Pad for Smartphones","price":"19.00","discountPercentage":"15.00","finalPrice":"16.15","category":"Electronics"},
-        {"sku":"SKU0023","description":"Men's Quartz Analog Watch with Leather Strap","price":"55.00","discountPercentage":"0.00","finalPrice":"55.00","category":"Accessories"},
-        {"sku":"SKU0024","description":"Wooden Chess Set with Folding Board","price":"30.00","discountPercentage":"0.00","finalPrice":"30.00","category":"Toys & Games"},
-        {"sku":"SKU0025","description":"Home Security Camera with Night Vision","price":"99.00","discountPercentage":"30.00","finalPrice":"69.30","category":"Electronics"},
-        {"sku":"SKU0026","description":"Aromatherapy Essential Oil Diffuser","price":"16.50","discountPercentage":"25.00","finalPrice":"12.38","category":"Home & Kitchen"},
-        {"sku":"SKU0027","description":"Professional Blender with 2L Jar","price":"40.00","discountPercentage":"0.00","finalPrice":"40.00","category":"Home Appliances"},
-        {"sku":"SKU0028","description":"Kids' Educational Tablet Toy","price":"22.00","discountPercentage":"0.00","finalPrice":"22.00","category":"Toys & Games"},
-        {"sku":"SKU0029","description":"Mechanical Gaming Keyboard with RGB Lighting","price":"110.00","discountPercentage":"15.00","finalPrice":"93.50","category":"Electronics"},
-        {"sku":"SKU0030","description":"Pack of 10 Ballpoint Pens, Blue Ink","price":"7.50","discountPercentage":"0.00","finalPrice":"7.50","category":"Stationery"}
-      ],
-      "page":0,
-      "size":30,
-      "totalElements":30,
-      "totalPages":1
-    }
-    """.trimIndent()
+    val expectedJson = loadJson("all_products_page0_size30.json")
 
     val actualJson = given()
         .contentType("application/json")
@@ -74,26 +34,7 @@ abstract class GetProductCatalogTestCase : TestCase() {
   // TODO: I should add a parameterized test to verify that can filter by any category
   @Test
   fun `should return only electronics items when filtering by category Electronics`() {
-    val expectedJson = """
-    {
-      "products": [
-        {"sku":"SKU0001","description":"Wireless Mouse with ergonomic design","price":"19.99","discountPercentage":"15.00","finalPrice":"16.99","category":"Electronics"},
-        {"sku":"SKU0002","description":"4K Ultra HD Smart TV, 55 inches","price":"499.00","discountPercentage":"15.00","finalPrice":"424.15","category":"Electronics"},
-        {"sku":"SKU0005","description":"Noise-Cancelling Over-Ear Headphones","price":"120.00","discountPercentage":"30.00","finalPrice":"84.00","category":"Electronics"},
-        {"sku":"SKU0006","description":"USB-C to USB Adapter","price":"9.99","discountPercentage":"15.00","finalPrice":"8.49","category":"Electronics"},
-        {"sku":"SKU0009","description":"Smartwatch with Heart Rate Monitor","price":"220.00","discountPercentage":"15.00","finalPrice":"187.00","category":"Electronics"},
-        {"sku":"SKU0011","description":"Bluetooth Portable Speaker","price":"60.00","discountPercentage":"15.00","finalPrice":"51.00","category":"Electronics"},
-        {"sku":"SKU0018","description":"DSLR Camera with 18-55mm Lens","price":"300.00","discountPercentage":"15.00","finalPrice":"255.00","category":"Electronics"},
-        {"sku":"SKU0022","description":"Wireless Charger Pad for Smartphones","price":"19.00","discountPercentage":"15.00","finalPrice":"16.15","category":"Electronics"},
-        {"sku":"SKU0025","description":"Home Security Camera with Night Vision","price":"99.00","discountPercentage":"30.00","finalPrice":"69.30","category":"Electronics"},
-        {"sku":"SKU0029","description":"Mechanical Gaming Keyboard with RGB Lighting","price":"110.00","discountPercentage":"15.00","finalPrice":"93.50","category":"Electronics"}
-      ],
-      "page":0,
-      "size":20,
-      "totalElements":10,
-      "totalPages":1
-    }
-    """.trimIndent()
+    val expectedJson = loadJson("electronics_default_page.json")
 
     val actualJson = given()
         .contentType("application/json")
@@ -171,4 +112,11 @@ abstract class GetProductCatalogTestCase : TestCase() {
     assertEquals(6, tree["totalPages"].asInt())
     assertEquals(5, tree["products"].size())
   }
+
+  private fun loadJson(name: String): String =
+      javaClass.classLoader
+          .getResourceAsStream("responses/$name")
+          ?.bufferedReader(Charsets.UTF_8)
+          ?.use { it.readText().trimIndent() }
+        ?: error("Could not load resource responses/$name")
 }

--- a/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/TestCase.kt
+++ b/src/integrationTest/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/testcases/TestCase.kt
@@ -2,6 +2,8 @@ package com.capitole.capitoleproductcatalogapi.infrastructure.testcases
 
 
 import com.capitole.capitoleproductcatalogapi.Application
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.restassured.module.mockmvc.RestAssuredMockMvc.mockMvc
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import java.nio.charset.StandardCharsets
 
 @SpringBootTest(classes = [Application::class])
 @ActiveProfiles("integration-test")
@@ -17,8 +20,18 @@ abstract class TestCase {
 
   @Autowired private lateinit var mvc: MockMvc
 
+  protected lateinit var mapper: ObjectMapper
+
   @BeforeEach
   fun setUp() {
+    mapper = ObjectMapper()
     mockMvc(mvc)
   }
+
+  protected fun loadFixture(name: String): JsonNode =
+      javaClass.classLoader
+          .getResourceAsStream("responses/$name")
+          ?.bufferedReader(StandardCharsets.UTF_8)
+          ?.use { mapper.readTree(it) }
+        ?: error("Fixture not found: responses/$name")
 }

--- a/src/integrationTest/resources/responses/all_products_page0_size30.json
+++ b/src/integrationTest/resources/responses/all_products_page0_size30.json
@@ -1,0 +1,248 @@
+{
+  "products": [
+    {
+      "sku": "SKU0001",
+      "description": "Wireless Mouse with ergonomic design",
+      "price": "19.99",
+      "discountPercentage": "15.00",
+      "finalPrice": "16.99",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0002",
+      "description": "4K Ultra HD Smart TV, 55 inches",
+      "price": "499.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "424.15",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0003",
+      "description": "Stainless Steel Water Bottle, 1L",
+      "price": "29.50",
+      "discountPercentage": "25.00",
+      "finalPrice": "22.13",
+      "category": "Home & Kitchen"
+    },
+    {
+      "sku": "SKU0004",
+      "description": "Cotton T-Shirt, Unisex, Size M",
+      "price": "15.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "15.00",
+      "category": "Clothing"
+    },
+    {
+      "sku": "SKU0005",
+      "description": "Noise-Cancelling Over-Ear Headphones",
+      "price": "120.00",
+      "discountPercentage": "30.00",
+      "finalPrice": "84.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0006",
+      "description": "USB-C to USB Adapter",
+      "price": "9.99",
+      "discountPercentage": "15.00",
+      "finalPrice": "8.49",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0007",
+      "description": "Leather Wallet with RFID Protection",
+      "price": "75.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "75.00",
+      "category": "Accessories"
+    },
+    {
+      "sku": "SKU0008",
+      "description": "Yoga Mat with Non-Slip Surface",
+      "price": "35.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "35.00",
+      "category": "Sports"
+    },
+    {
+      "sku": "SKU0009",
+      "description": "Smartwatch with Heart Rate Monitor",
+      "price": "220.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "187.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0010",
+      "description": "Ceramic Coffee Mug, 350ml",
+      "price": "12.50",
+      "discountPercentage": "25.00",
+      "finalPrice": "9.38",
+      "category": "Home & Kitchen"
+    },
+    {
+      "sku": "SKU0011",
+      "description": "Bluetooth Portable Speaker",
+      "price": "60.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "51.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0012",
+      "description": "Backpack with Laptop Compartment",
+      "price": "85.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "85.00",
+      "category": "Accessories"
+    },
+    {
+      "sku": "SKU0013",
+      "description": "Stainless Steel Cutlery Set, 24 Pieces",
+      "price": "18.00",
+      "discountPercentage": "25.00",
+      "finalPrice": "13.50",
+      "category": "Home & Kitchen"
+    },
+    {
+      "sku": "SKU0014",
+      "description": "Electric Guitar Starter Pack",
+      "price": "250.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "250.00",
+      "category": "Musical Instruments"
+    },
+    {
+      "sku": "SKU0015",
+      "description": "Running Shoes, Men's Size 42",
+      "price": "42.00",
+      "discountPercentage": "30.00",
+      "finalPrice": "29.40",
+      "category": "Footwear"
+    },
+    {
+      "sku": "SKU0016",
+      "description": "Digital Bathroom Scale with Body Fat Analyzer",
+      "price": "27.99",
+      "discountPercentage": "0.00",
+      "finalPrice": "27.99",
+      "category": "Home Appliances"
+    },
+    {
+      "sku": "SKU0017",
+      "description": "Set of 6 Organic Cotton Socks",
+      "price": "14.99",
+      "discountPercentage": "0.00",
+      "finalPrice": "14.99",
+      "category": "Clothing"
+    },
+    {
+      "sku": "SKU0018",
+      "description": "DSLR Camera with 18-55mm Lens",
+      "price": "300.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "255.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0019",
+      "description": "Hardcover Notebook, A5, 200 Pages",
+      "price": "8.99",
+      "discountPercentage": "0.00",
+      "finalPrice": "8.99",
+      "category": "Stationery"
+    },
+    {
+      "sku": "SKU0020",
+      "description": "Microwave Oven, 20L Capacity",
+      "price": "65.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "65.00",
+      "category": "Home Appliances"
+    },
+    {
+      "sku": "SKU0021",
+      "description": "LED Desk Lamp with Adjustable Brightness",
+      "price": "23.50",
+      "discountPercentage": "25.00",
+      "finalPrice": "17.63",
+      "category": "Home & Kitchen"
+    },
+    {
+      "sku": "SKU0022",
+      "description": "Wireless Charger Pad for Smartphones",
+      "price": "19.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "16.15",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0023",
+      "description": "Men's Quartz Analog Watch with Leather Strap",
+      "price": "55.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "55.00",
+      "category": "Accessories"
+    },
+    {
+      "sku": "SKU0024",
+      "description": "Wooden Chess Set with Folding Board",
+      "price": "30.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "30.00",
+      "category": "Toys & Games"
+    },
+    {
+      "sku": "SKU0025",
+      "description": "Home Security Camera with Night Vision",
+      "price": "99.00",
+      "discountPercentage": "30.00",
+      "finalPrice": "69.30",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0026",
+      "description": "Aromatherapy Essential Oil Diffuser",
+      "price": "16.50",
+      "discountPercentage": "25.00",
+      "finalPrice": "12.38",
+      "category": "Home & Kitchen"
+    },
+    {
+      "sku": "SKU0027",
+      "description": "Professional Blender with 2L Jar",
+      "price": "40.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "40.00",
+      "category": "Home Appliances"
+    },
+    {
+      "sku": "SKU0028",
+      "description": "Kids' Educational Tablet Toy",
+      "price": "22.00",
+      "discountPercentage": "0.00",
+      "finalPrice": "22.00",
+      "category": "Toys & Games"
+    },
+    {
+      "sku": "SKU0029",
+      "description": "Mechanical Gaming Keyboard with RGB Lighting",
+      "price": "110.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "93.50",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0030",
+      "description": "Pack of 10 Ballpoint Pens, Blue Ink",
+      "price": "7.50",
+      "discountPercentage": "0.00",
+      "finalPrice": "7.50",
+      "category": "Stationery"
+    }
+  ],
+  "page": 0,
+  "size": 30,
+  "totalElements": 30,
+  "totalPages": 1
+}

--- a/src/integrationTest/resources/responses/electronics_default_page.json
+++ b/src/integrationTest/resources/responses/electronics_default_page.json
@@ -1,0 +1,88 @@
+{
+  "products": [
+    {
+      "sku": "SKU0001",
+      "description": "Wireless Mouse with ergonomic design",
+      "price": "19.99",
+      "discountPercentage": "15.00",
+      "finalPrice": "16.99",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0002",
+      "description": "4K Ultra HD Smart TV, 55 inches",
+      "price": "499.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "424.15",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0005",
+      "description": "Noise-Cancelling Over-Ear Headphones",
+      "price": "120.00",
+      "discountPercentage": "30.00",
+      "finalPrice": "84.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0006",
+      "description": "USB-C to USB Adapter",
+      "price": "9.99",
+      "discountPercentage": "15.00",
+      "finalPrice": "8.49",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0009",
+      "description": "Smartwatch with Heart Rate Monitor",
+      "price": "220.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "187.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0011",
+      "description": "Bluetooth Portable Speaker",
+      "price": "60.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "51.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0018",
+      "description": "DSLR Camera with 18-55mm Lens",
+      "price": "300.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "255.00",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0022",
+      "description": "Wireless Charger Pad for Smartphones",
+      "price": "19.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "16.15",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0025",
+      "description": "Home Security Camera with Night Vision",
+      "price": "99.00",
+      "discountPercentage": "30.00",
+      "finalPrice": "69.30",
+      "category": "Electronics"
+    },
+    {
+      "sku": "SKU0029",
+      "description": "Mechanical Gaming Keyboard with RGB Lighting",
+      "price": "110.00",
+      "discountPercentage": "15.00",
+      "finalPrice": "93.50",
+      "category": "Electronics"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 10,
+  "totalPages": 1
+}

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
@@ -4,35 +4,37 @@ import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Product
 import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 
 class GetProductCatalog(
-  private val productRepository: ProductRepository,
-  private val discountService: DiscountService
+    private val productRepository: ProductRepository,
+    private val discountService: DiscountService
 ) {
-  fun execute(
-    categoryFilter: Category? = null,
-    sortField: SortField?,
-    sortOrder: SortOrder,
-  ): ProductCatalogDTO {
-    val products = productRepository.findAll(categoryFilter, sortField, sortOrder)
-    return products.toProductCatalogDTO(discountService)
-  }
+    fun execute(
+        categoryFilter: Category? = null,
+        sortField: SortField?,
+        sortOrder: SortOrder,
+    ): ProductCatalogDTO {
+        val sortSpec = SortSpec.of(sortField, sortOrder)
+        val products = productRepository.findAll(categoryFilter, sortSpec)
+        return products.toProductCatalogDTO(discountService)
+    }
 }
 
 private fun List<Product>.toProductCatalogDTO(discountService: DiscountService): ProductCatalogDTO {
-  val productDTOs = this.map { product ->
-    val discount = discountService.getApplicableDiscount(product)
-    val finalPrice = product.calculatePriceAfterDiscount(discount)
-    ProductCatalogDTO.ProductDTO(
-        sku = product.sku.value,
-        description = product.description.value,
-        price = product.price.toDTO(),
-        discountPercentage = discount.toDTO(),
-        finalPrice = finalPrice,
-        category = product.category.toDTO()
-    )
-  }
-  return ProductCatalogDTO(productDTOs)
+    val productDTOs = this.map { product ->
+        val discount = discountService.getApplicableDiscount(product)
+        val finalPrice = product.calculatePriceAfterDiscount(discount)
+        ProductCatalogDTO.ProductDTO(
+            sku = product.sku.value,
+            description = product.description.value,
+            price = product.price.toDTO(),
+            discountPercentage = discount.toDTO(),
+            finalPrice = finalPrice,
+            category = product.category.toDTO()
+        )
+    }
+    return ProductCatalogDTO(productDTOs)
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
@@ -1,6 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
 
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Product
 import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
@@ -16,9 +17,10 @@ class GetProductCatalog(
         categoryFilter: Category? = null,
         sortField: SortField?,
         sortOrder: SortOrder,
+        pageRequest: PageRequest
     ): ProductCatalogDTO {
         val sortSpec = SortSpec.of(sortField, sortOrder)
-        val products = productRepository.findAll(categoryFilter, sortSpec)
+        val products = productRepository.findAll(categoryFilter, sortSpec, pageRequest)
         return products.toProductCatalogDTO(discountService)
     }
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
@@ -39,5 +39,11 @@ private fun Page<Product>.toProductCatalogDTO(discountService: DiscountService):
             category = product.category.toDTO()
         )
     }
-    return ProductCatalogDTO(productDTOs)
+    return ProductCatalogDTO(
+        products = productDTOs,
+        page = pageNumber,
+        size = pageSize,
+        totalElements = totalElements,
+        totalPages = totalPages
+    )
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/GetProductCatalog.kt
@@ -1,6 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
 
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
+import com.capitole.capitoleproductcatalogapi.domain.pagination.Page
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Product
@@ -25,8 +26,8 @@ class GetProductCatalog(
     }
 }
 
-private fun List<Product>.toProductCatalogDTO(discountService: DiscountService): ProductCatalogDTO {
-    val productDTOs = this.map { product ->
+private fun Page<Product>.toProductCatalogDTO(discountService: DiscountService): ProductCatalogDTO {
+    val productDTOs = this.content.map { product ->
         val discount = discountService.getApplicableDiscount(product)
         val finalPrice = product.calculatePriceAfterDiscount(discount)
         ProductCatalogDTO.ProductDTO(

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/ProductCatalogDTO.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/ProductCatalogDTO.kt
@@ -1,6 +1,12 @@
 package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
 
-data class ProductCatalogDTO(val products: List<ProductDTO>) {
+data class ProductCatalogDTO(
+  val products: List<ProductDTO>,
+  val page: Int,
+  val size: Int,
+  val totalElements: Long,
+  val totalPages: Int
+) {
   data class ProductDTO(
     val sku: String,
     val description: String,

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/CategoryDTO.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/CategoryDTO.kt
@@ -1,4 +1,4 @@
-package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
+package com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto
 
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/DiscountPercentageDTO.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/DiscountPercentageDTO.kt
@@ -1,4 +1,4 @@
-package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
+package com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto
 
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountPercentage
 

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/GetProductCatalog.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/GetProductCatalog.kt
@@ -1,5 +1,6 @@
-package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
+package com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto
 
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
 import com.capitole.capitoleproductcatalogapi.domain.pagination.Page
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/ProductCatalogDTO.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/ProductCatalogDTO.kt
@@ -1,4 +1,6 @@
-package com.capitole.capitoleproductcatalogapi.application.getproductcatalog
+package com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto
+
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.PriceDTO
 
 data class ProductCatalogDTO(
   val products: List<ProductDTO>,

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/Page.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/Page.kt
@@ -1,0 +1,11 @@
+package com.capitole.capitoleproductcatalogapi.domain.pagination
+
+data class Page<T>(
+  val content: List<T>,
+  val pageNumber: Int,
+  val pageSize: Int,
+  val totalElements: Long
+) {
+  val totalPages: Int
+    get() = if (pageSize == 0) 0 else ((totalElements + pageSize - 1) / pageSize).toInt()
+}

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequest.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequest.kt
@@ -1,0 +1,22 @@
+package com.capitole.capitoleproductcatalogapi.domain.pagination
+
+data class PageRequest(
+  val page: Int,
+  val size: Int
+) {
+  init {
+    // TODO: Throw custom domain exceptions
+    require(page >= 0) { "page index must be non‐negative, was $page" }
+    require(size > 0) { "page size must be positive, was $size" }
+  }
+
+  companion object {
+    private const val DEFAULT_PAGE = 0
+    private const val DEFAULT_PAGE_SIZE = 20
+    fun of(pageParam: Int?, sizeParam: Int?): PageRequest {
+      val p = pageParam?.takeIf { it >= 0 } ?: DEFAULT_PAGE
+      val s = sizeParam?.takeIf { it > 0 } ?: DEFAULT_PAGE_SIZE
+      return PageRequest(p, s)
+    }
+  }
+}

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequest.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequest.kt
@@ -4,11 +4,11 @@ data class PageRequest(
   val page: Int,
   val size: Int
 ) {
-  init {
-    // TODO: Throw custom domain exceptions
-    require(page >= 0) { "page index must be non‐negative, was $page" }
-    require(size > 0) { "page size must be positive, was $size" }
-  }
+  /*
+   TODO: Thorw custom exceptions when:
+    1. Page is negative
+    2. Size is negative
+   */
 
   companion object {
     private const val DEFAULT_PAGE = 0

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
@@ -1,5 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.domain.product
 
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
+
 interface ProductRepository {
-    fun findAll(categoryFilter: Category? = null, sortField: SortField?, sortOrder: SortOrder): List<Product>
+  fun findAll(categoryFilter: Category? = null, sort: SortSpec? = null): List<Product>
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
@@ -1,7 +1,8 @@
 package com.capitole.capitoleproductcatalogapi.domain.product
 
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 
 interface ProductRepository {
-  fun findAll(categoryFilter: Category? = null, sort: SortSpec? = null): List<Product>
+  fun findAll(categoryFilter: Category? = null, sort: SortSpec? = null, pageRequest: PageRequest): List<Product>
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/ProductRepository.kt
@@ -1,8 +1,9 @@
 package com.capitole.capitoleproductcatalogapi.domain.product
 
+import com.capitole.capitoleproductcatalogapi.domain.pagination.Page
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 
 interface ProductRepository {
-  fun findAll(categoryFilter: Category? = null, sort: SortSpec? = null, pageRequest: PageRequest): List<Product>
+  fun findAll(categoryFilter: Category? = null, sort: SortSpec? = null, pageRequest: PageRequest): Page<Product>
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/SortField.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/SortField.kt
@@ -1,3 +1,0 @@
-package com.capitole.capitoleproductcatalogapi.domain.product
-
-enum class SortField { SKU, PRICE, DESCRIPTION, CATEGORY }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/SortOrder.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/SortOrder.kt
@@ -1,3 +1,0 @@
-package com.capitole.capitoleproductcatalogapi.domain.product
-
-enum class SortOrder { ASC, DESC }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortField.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortField.kt
@@ -1,0 +1,3 @@
+package com.capitole.capitoleproductcatalogapi.domain.product.sort
+
+enum class SortField { SKU, PRICE, DESCRIPTION, CATEGORY }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortOrder.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortOrder.kt
@@ -1,0 +1,3 @@
+package com.capitole.capitoleproductcatalogapi.domain.product.sort
+
+enum class SortOrder { ASC, DESC }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortSpec.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortSpec.kt
@@ -1,0 +1,10 @@
+package com.capitole.capitoleproductcatalogapi.domain.product.sort
+
+data class SortSpec(
+  val field: SortField,
+  val order: SortOrder
+) {
+  companion object {
+    fun of(sortField: SortField?, order: SortOrder): SortSpec = SortSpec(sortField ?: SortField.SKU, order)
+  }
+}

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/configuration/ApplicationConfiguration.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/configuration/ApplicationConfiguration.kt
@@ -1,6 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.configuration
 
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.GetProductCatalog
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
 import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/configuration/InfrastructureConfiguration.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/configuration/InfrastructureConfiguration.kt
@@ -16,11 +16,11 @@ class InfrastructureConfiguration {
 
   // TODO: Just to test "main" environment with dummy data (OpenApi)
   @Bean
-  @Profile("!integration‑test")
+  @Profile("!integration-test")
   fun inMemoryProductRepository() = InMemoryProductRepository()
 
   @Bean
-  @Profile("integration‑test")
+  @Profile("integration-test")
   fun productRepository(
     jdbcTemplate: NamedParameterJdbcTemplate,
     productSQLBuilder: ProductSQLBuilder

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
@@ -2,8 +2,8 @@ package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getpro
 
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
@@ -1,6 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getproductcatalog
 
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.GetProductCatalog
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogController.kt
@@ -1,6 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getproductcatalog
 
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
@@ -18,10 +19,13 @@ class GetProductCatalogController(
   override fun getProductCatalog(
     category: String?,
     sortField: SortField?,
-    sortOrder: SortOrder
+    sortOrder: SortOrder,
+    page: Int,
+    size: Int
   ): ResponseEntity<GetProductCatalogResponse> {
     val catEnum = category?.let { Category.from(it) }
-    val dto = getProductCatalog.execute(catEnum, sortField, sortOrder)
+    val pageRequest = PageRequest.of(page, size)
+    val dto = getProductCatalog.execute(catEnum, sortField, sortOrder, pageRequest)
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
         .body(dto.toGetProductCatalogResponse())

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogControllerApi.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogControllerApi.kt
@@ -1,7 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getproductcatalog
 
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogControllerApi.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogControllerApi.kt
@@ -9,12 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestParam
 
-@Tag(name = "Products", description = "Retrieve, filter & sort product catalog")
+@Tag(name = "Products", description = "Retrieve, filter, sort & paginate product catalog")
 interface ProductCatalogApi {
 
   @Operation(
       summary = "List products",
-      description = "Returns all products, with optional filtering by category and sorting"
+      description = "Returns a page of products, with optional filtering by category, sorting and pagination"
   )
   fun getProductCatalog(
     @Parameter(
@@ -30,15 +30,24 @@ interface ProductCatalogApi {
         ),
         required = false
     )
-    @RequestParam("category", required = false)
+    @RequestParam(name = "category", required = false)
     category: String?,
 
     @Parameter(description = "Sort field: SKU, PRICE, DESCRIPTION or CATEGORY")
-    @RequestParam("sortField", required = false)
+    @RequestParam(name = "sortField", required = false)
     sortField: SortField?,
 
     @Parameter(description = "Sort order: ASC or DESC")
-    @RequestParam("sortOrder", required = false, defaultValue = "ASC")
-    sortOrder: SortOrder
+    @RequestParam(name = "sortOrder", required = false, defaultValue = "ASC")
+    sortOrder: SortOrder,
+
+    @Parameter(description = "Page index (0-based)", example = "0")
+    @RequestParam(name = "page", required = false, defaultValue = "0")
+    page: Int,
+
+    @Parameter(description = "Page size", example = "20")
+    @RequestParam(name = "size", required = false, defaultValue = "20")
+    size: Int
+
   ): ResponseEntity<GetProductCatalogResponse>
 }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogResponse.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogResponse.kt
@@ -1,6 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getproductcatalog
 
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.ProductCatalogDTO
 
 data class GetProductCatalogResponse(
   val products: List<ProductResponse>,

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogResponse.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/controllers/getproductcatalog/GetProductCatalogResponse.kt
@@ -3,7 +3,11 @@ package com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getpro
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
 
 data class GetProductCatalogResponse(
-  val products: List<ProductResponse>
+  val products: List<ProductResponse>,
+  val page: Int,
+  val size: Int,
+  val totalElements: Long,
+  val totalPages: Int
 ) {
   data class ProductResponse(
     val sku: String,
@@ -25,5 +29,9 @@ fun ProductCatalogDTO.toGetProductCatalogResponse(): GetProductCatalogResponse =
           finalPrice = productDTO.finalPrice,
           category = productDTO.category.displayName
       )
-    }
+    },
+    page = page,
+    size = size,
+    totalElements = totalElements,
+    totalPages = totalPages
 )

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/InMemoryProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/InMemoryProductRepository.kt
@@ -1,5 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.product
 
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Description
 import com.capitole.capitoleproductcatalogapi.domain.product.Price
@@ -87,7 +88,8 @@ class InMemoryProductRepository : ProductRepository {
 
   override fun findAll(
     categoryFilter: Category?,
-    sort: SortSpec?
+    sort: SortSpec?,
+    pageRequest: PageRequest
   ): List<Product> {
     var result = data
 

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/InMemoryProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/InMemoryProductRepository.kt
@@ -6,8 +6,9 @@ import com.capitole.capitoleproductcatalogapi.domain.product.Price
 import com.capitole.capitoleproductcatalogapi.domain.product.Product
 import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
 import com.capitole.capitoleproductcatalogapi.domain.product.SKU
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 
 class InMemoryProductRepository : ProductRepository {
 
@@ -86,8 +87,7 @@ class InMemoryProductRepository : ProductRepository {
 
   override fun findAll(
     categoryFilter: Category?,
-    sortField: SortField?,
-    sortOrder: SortOrder
+    sort: SortSpec?
   ): List<Product> {
     var result = data
 
@@ -95,13 +95,13 @@ class InMemoryProductRepository : ProductRepository {
       result = result.filter { p -> p.category == it }
     }
 
-    sortField?.let { field ->
+    sort?.field?.let { field ->
       result = when (field) {
         SortField.SKU -> result.sortedByOrNull { it.sku.value }
         SortField.PRICE -> result.sortedByOrNull { it.price.value }
         SortField.DESCRIPTION -> result.sortedByOrNull { it.description.value }
         SortField.CATEGORY -> result.sortedByOrNull { it.category.name }
-      }.let { if (sortOrder == SortOrder.DESC) it.reversed() else it }
+      }.let { if (sort.order == SortOrder.DESC) it.reversed() else it }
     }
 
     return result

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
@@ -1,5 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.product
 
+import com.capitole.capitoleproductcatalogapi.domain.pagination.Page
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.*
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
@@ -8,29 +9,53 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 
 class PostgresSQLProductRepository(
-  private val jdbcTemplate: NamedParameterJdbcTemplate,
-  private val sqlBuilder: ProductSQLBuilder
+    private val jdbcTemplate: NamedParameterJdbcTemplate,
+    private val sqlBuilder: ProductSQLBuilder
 ) : ProductRepository {
 
-  override fun findAll(
-      categoryFilter: Category?,
-      sort: SortSpec?,
-      pageRequest: PageRequest
-  ): List<Product> {
-    val params = MapSqlParameterSource()
-      val sql = sqlBuilder.buildFindAllQuery(categoryFilter, sort, params)
-    return jdbcTemplate.query(sql, params, productRowMapper)
-  }
+    override fun findAll(
+        categoryFilter: Category?,
+        sort: SortSpec?,
+        pageRequest: PageRequest
+    ): Page<Product> {
+        val params = buildQueryParams(categoryFilter, sort, pageRequest)
+        val contentSql = sqlBuilder.buildFindAllQuery(categoryFilter, sort)
+        val content = jdbcTemplate.query(contentSql, params, productRowMapper)
 
-  companion object {
-    private val productRowMapper = RowMapper<Product> { rs, _ ->
-      Product(
-          sku = SKU(rs.getString("sku")),
-          description = Description(rs.getString("description")),
-          price = Price(rs.getDouble("price")),
-          category = Category.valueOf(rs.getString("category"))
-      )
+        val countSql = sqlBuilder.buildCountQuery(categoryFilter)
+        val totalElements = jdbcTemplate.queryForObject(countSql, params, Long::class.java) ?: 0L
+
+        return Page(
+            content = content,
+            pageNumber = pageRequest.page,
+            pageSize = pageRequest.size,
+            totalElements = totalElements
+        )
     }
-  }
-}
 
+    private fun buildQueryParams(
+        category: Category?,
+        sort: SortSpec?,
+        pageRequest: PageRequest
+    ): MapSqlParameterSource =
+        MapSqlParameterSource().apply {
+            category?.let { addValue("category", it.name) }
+            sort?.let {
+                addValue("sortField", it.field.name)
+                addValue("sortOrder", it.order.name)
+            }
+            addValue("limit", pageRequest.size)
+            addValue("offset", pageRequest.page * pageRequest.size)
+        }
+
+    private companion object {
+        val productRowMapper = RowMapper<Product> { rs, _ ->
+            Product(
+                sku = SKU(rs.getString("sku")),
+                description = Description(rs.getString("description")),
+                price = Price(rs.getDouble("price")),
+                category = Category.valueOf(rs.getString("category"))
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
@@ -1,5 +1,6 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.product
 
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.*
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 import org.springframework.jdbc.core.RowMapper
@@ -13,7 +14,8 @@ class PostgresSQLProductRepository(
 
   override fun findAll(
       categoryFilter: Category?,
-      sort: SortSpec?
+      sort: SortSpec?,
+      pageRequest: PageRequest
   ): List<Product> {
     val params = MapSqlParameterSource()
       val sql = sqlBuilder.buildFindAllQuery(categoryFilter, sort, params)

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/PostgresSQLProductRepository.kt
@@ -1,13 +1,7 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.product
 
-import com.capitole.capitoleproductcatalogapi.domain.product.Category
-import com.capitole.capitoleproductcatalogapi.domain.product.Description
-import com.capitole.capitoleproductcatalogapi.domain.product.Price
-import com.capitole.capitoleproductcatalogapi.domain.product.Product
-import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
-import com.capitole.capitoleproductcatalogapi.domain.product.SKU
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.*
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -18,12 +12,11 @@ class PostgresSQLProductRepository(
 ) : ProductRepository {
 
   override fun findAll(
-    categoryFilter: Category?,
-    sortField: SortField?,
-    sortOrder: SortOrder
+      categoryFilter: Category?,
+      sort: SortSpec?
   ): List<Product> {
     val params = MapSqlParameterSource()
-    val sql = sqlBuilder.buildFindAllQuery(categoryFilter, sortField, sortOrder, params)
+      val sql = sqlBuilder.buildFindAllQuery(categoryFilter, sort, params)
     return jdbcTemplate.query(sql, params, productRowMapper)
   }
 

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/ProductSQLBuilder.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/ProductSQLBuilder.kt
@@ -1,8 +1,8 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.product
 
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 
 class ProductSQLBuilder {
@@ -15,10 +15,9 @@ class ProductSQLBuilder {
   )
 
   fun buildFindAllQuery(
-    category: Category?,
-    sortField: SortField?,
-    sortOrder: SortOrder,
-    params: MapSqlParameterSource
+      category: Category?,
+      sort: SortSpec?,
+      params: MapSqlParameterSource
   ): String {
     val query = StringBuilder(
         """
@@ -32,11 +31,11 @@ class ProductSQLBuilder {
       params.addValue("category", it.name)
     }
 
-    sortField?.also { field ->
-      val column = fieldToColumn[field]
-        ?: throw IllegalArgumentException("Unsupported sort field: $field")
-      query.append("\n ORDER BY $column ${sortOrder.name}")
-    }
+      sort?.field.also { field ->
+          val column = fieldToColumn[field]
+              ?: throw IllegalArgumentException("Unsupported sort field: $field")
+          query.append("\n ORDER BY $column ${sort?.order?.name}")
+      }
 
     return query.toString()
   }

--- a/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/ProductSQLBuilder.kt
+++ b/src/main/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/repositories/product/ProductSQLBuilder.kt
@@ -3,40 +3,49 @@ package com.capitole.capitoleproductcatalogapi.infrastructure.repositories.produ
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 
 class ProductSQLBuilder {
 
-  private val fieldToColumn = mapOf(
-      SortField.SKU to "sku",
-      SortField.PRICE to "price",
-      SortField.DESCRIPTION to "description",
-      SortField.CATEGORY to "category"
-  )
-
-  fun buildFindAllQuery(
-      category: Category?,
-      sort: SortSpec?,
-      params: MapSqlParameterSource
-  ): String {
-    val query = StringBuilder(
-        """
-      SELECT sku, description, price, category
-        FROM products
-    """.trimIndent()
+    private val fieldToColumn = mapOf(
+        SortField.SKU to "sku",
+        SortField.PRICE to "price",
+        SortField.DESCRIPTION to "description",
+        SortField.CATEGORY to "category"
     )
 
-    category?.also {
-      query.append("\n WHERE category = CAST(:category AS category_enum)")
-      params.addValue("category", it.name)
+    fun buildFindAllQuery(
+        category: Category?,
+        sort: SortSpec?
+    ): String {
+        val sql = StringBuilder(
+            """
+      SELECT sku,
+             description,
+             price,
+             category
+        FROM products
+    """.trimIndent()
+        )
+
+        category?.also {
+            sql.append("\n WHERE category = CAST(:category AS category_enum)")
+        }
+
+        sort?.let { spec ->
+            val col = fieldToColumn[spec.field]
+                ?: error("Unsupported sort field: ${spec.field}")
+            sql.append("\n ORDER BY $col ${spec.order.name}")
+        }
+
+        sql.append("\n LIMIT :limit OFFSET :offset")
+        return sql.toString()
     }
 
-      sort?.field.also { field ->
-          val column = fieldToColumn[field]
-              ?: throw IllegalArgumentException("Unsupported sort field: $field")
-          query.append("\n ORDER BY $column ${sort?.order?.name}")
-      }
-
-    return query.toString()
-  }
+    fun buildCountQuery(category: Category?): String {
+        val sql = StringBuilder("SELECT COUNT(*) FROM products")
+        category?.also {
+            sql.append("\n WHERE category = CAST(:category AS category_enum)")
+        }
+        return sql.toString()
+    }
 }

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
@@ -1,10 +1,10 @@
 package com.capitole.capitoleproductcatalogapi.application
 
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.DiscountPercentageDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.PriceDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.DiscountPercentageDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.GetProductCatalog
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.ProductCatalogDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountPercentage
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
 import com.capitole.capitoleproductcatalogapi.domain.pagination.Page

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
@@ -13,8 +13,9 @@ import com.capitole.capitoleproductcatalogapi.domain.product.Price
 import com.capitole.capitoleproductcatalogapi.domain.product.Product
 import com.capitole.capitoleproductcatalogapi.domain.product.ProductRepository
 import com.capitole.capitoleproductcatalogapi.domain.product.SKU
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortSpec
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,7 +54,7 @@ class GetProductCatalogTest {
         )
     )
 
-    `when`(productRepository.findAll(sortField = SortField.PRICE, sortOrder = SortOrder.ASC)).thenReturn(products)
+    `when`(productRepository.findAll(sort = SortSpec(SortField.PRICE, SortOrder.ASC))).thenReturn(products)
     `when`(discountService.getApplicableDiscount(products[0])).thenReturn(DiscountPercentage(0.0))
     `when`(discountService.getApplicableDiscount(products[1])).thenReturn(DiscountPercentage(30.0))
 

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
@@ -7,6 +7,7 @@ import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.Prod
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountPercentage
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
+import com.capitole.capitoleproductcatalogapi.domain.pagination.Page
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Description
@@ -54,20 +55,26 @@ class GetProductCatalogTest {
             category = Category.ELECTRONICS
         )
     )
+    val paginatedProducts = Page(
+        content = products,
+        pageNumber = 0,
+        pageSize = 2,
+        totalElements = 2
+    )
 
     `when`(
         productRepository.findAll(
             sort = SortSpec(SortField.PRICE, SortOrder.ASC),
-            pageRequest = PageRequest.of(1, 2)
+            pageRequest = PageRequest.of(0, 2)
         )
-    ).thenReturn(products)
+    ).thenReturn(paginatedProducts)
     `when`(discountService.getApplicableDiscount(products[0])).thenReturn(DiscountPercentage(0.0))
     `when`(discountService.getApplicableDiscount(products[1])).thenReturn(DiscountPercentage(30.0))
 
     val result = getProductCatalog.execute(
         sortField = SortField.PRICE,
         sortOrder = SortOrder.ASC,
-        pageRequest = PageRequest.of(1, 2)
+        pageRequest = PageRequest.of(0, 2)
     )
 
     val expected = ProductCatalogDTO(

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
@@ -7,6 +7,7 @@ import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.Prod
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountPercentage
 import com.capitole.capitoleproductcatalogapi.domain.discount.DiscountService
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.Description
 import com.capitole.capitoleproductcatalogapi.domain.product.Price
@@ -54,11 +55,20 @@ class GetProductCatalogTest {
         )
     )
 
-    `when`(productRepository.findAll(sort = SortSpec(SortField.PRICE, SortOrder.ASC))).thenReturn(products)
+    `when`(
+        productRepository.findAll(
+            sort = SortSpec(SortField.PRICE, SortOrder.ASC),
+            pageRequest = PageRequest.of(1, 2)
+        )
+    ).thenReturn(products)
     `when`(discountService.getApplicableDiscount(products[0])).thenReturn(DiscountPercentage(0.0))
     `when`(discountService.getApplicableDiscount(products[1])).thenReturn(DiscountPercentage(30.0))
 
-    val result = getProductCatalog.execute(sortField = SortField.PRICE, sortOrder = SortOrder.ASC)
+    val result = getProductCatalog.execute(
+        sortField = SortField.PRICE,
+        sortOrder = SortOrder.ASC,
+        pageRequest = PageRequest.of(1, 2)
+    )
 
     val expected = ProductCatalogDTO(
         products = listOf(

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/GetProductCatalogTest.kt
@@ -95,7 +95,11 @@ class GetProductCatalogTest {
                 finalPrice = "84.00",
                 category = Category.ELECTRONICS.toDTO()
             )
-        )
+        ),
+        page = 0,
+        size = 2,
+        totalElements = 2,
+        totalPages = 1
     )
 
     assertEquals(expected, result)

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/CategoryDTOTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/application/getproductcatalog/dto/CategoryDTOTest.kt
@@ -1,0 +1,39 @@
+package com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto
+
+import com.capitole.capitoleproductcatalogapi.domain.product.Category
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
+
+class CategoryDtoTest {
+
+  @ParameterizedTest(name = "Category.{0} → displayName=\"{1}\"")
+  @CsvSource(
+      "ELECTRONICS,Electronics",
+      "HOME_AND_KITCHEN,Home & Kitchen",
+      "CLOTHING,Clothing",
+      "ACCESSORIES,Accessories",
+      "SPORTS,Sports",
+      "STATIONERY,Stationery",
+      "TOYS_AND_GAMES,Toys & Games",
+      "MUSICAL_INSTRUMENTS,Musical Instruments",
+      "FOOTWEAR,Footwear",
+      "HOME_APPLIANCES,Home Appliances"
+  )
+  fun `toDTO should set code and displayName correctly`(
+    enumName: String,
+    expectedDisplay: String
+  ) {
+    val category = Category.valueOf(enumName)
+    val dto = category.toDTO()
+
+    assertEquals(expectedDisplay, dto.displayName)
+
+    val codeField = CategoryDTO::class.java
+        .getDeclaredField("code")
+        .apply { isAccessible = true }
+
+    val actualCode = codeField.get(dto) as String
+    assertEquals(enumName, actualCode)
+  }
+}

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequestTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageRequestTest.kt
@@ -1,0 +1,40 @@
+package com.capitole.capitoleproductcatalogapi.domain.pagination
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class PageRequestTest {
+
+  @Test
+  fun `of(null, null) returns defaults`() {
+    val pr = PageRequest.of(null, null)
+    assertEquals(0, pr.page)
+    assertEquals(20, pr.size)
+  }
+
+  @ParameterizedTest(name = "pageParam={0}, sizeParam={1} yields page={2}, size={3}")
+  @CsvSource(
+      "0, 1, 0, 1",
+      "2, 50, 2, 50",
+      "-1, 5, 0, 5",
+      "-5, null, 0, 20",
+      "3, 0, 3, 20",
+      "3, -10, 3, 20",
+      "null, 10, 0, 10",
+      "1, null, 1, 20"
+  )
+  fun `of parameterized`(
+    pageParam: String?,
+    sizeParam: String?,
+    expectedPage: Int,
+    expectedSize: Int
+  ) {
+    val pageArg = pageParam?.takeIf { it != "null" }?.toInt()
+    val sizeArg = sizeParam?.takeIf { it != "null" }?.toInt()
+    val pr = PageRequest.of(pageArg, sizeArg)
+    assertEquals(expectedPage, pr.page)
+    assertEquals(expectedSize, pr.size)
+  }
+}

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/pagination/PageTest.kt
@@ -1,0 +1,67 @@
+package com.capitole.capitoleproductcatalogapi.domain.pagination
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PageTest {
+
+  @Test
+  fun `totalPages is zero when pageSize is zero`() {
+    val page = Page(
+        content = listOf("a", "b", "c"),
+        pageNumber = 0,
+        pageSize = 0,
+        totalElements = 42
+    )
+
+    assertEquals(0, page.totalPages)
+  }
+
+  @Test
+  fun `totalPages computes exact division`() {
+    val pageSize = 5
+    val totalElements = 20L
+    val page = Page(
+        content = emptyList<String>(),
+        pageNumber = 1,
+        pageSize = pageSize,
+        totalElements = totalElements
+    )
+
+    assertEquals(4, page.totalPages)
+  }
+
+  @Test
+  fun `totalPages computes with remainder rounds up`() {
+    val pageSize = 4
+    val totalElements = 10L
+    val page = Page(
+        content = emptyList<String>(),
+        pageNumber = 2,
+        pageSize = pageSize,
+        totalElements = totalElements
+    )
+
+    assertEquals(3, page.totalPages)
+  }
+
+  @Test
+  fun `properties reflect constructor arguments`() {
+    val items = listOf("x", "y")
+    val pageNumber = 3
+    val pageSize = 2
+    val totalElements = 7L
+
+    val page = Page(
+        content = items,
+        pageNumber = pageNumber,
+        pageSize = pageSize,
+        totalElements = totalElements
+    )
+
+    assertEquals(items, page.content)
+    assertEquals(pageNumber, page.pageNumber)
+    assertEquals(pageSize, page.pageSize)
+    assertEquals(totalElements, page.totalElements)
+  }
+}

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortSpecTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/domain/product/sort/SortSpecTest.kt
@@ -1,0 +1,31 @@
+package com.capitole.capitoleproductcatalogapi.domain.product.sort
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SortSpecTest {
+
+  @Test
+  fun `of should default field to SKU when sortField is null`() {
+    val spec = SortSpec.of(null, SortOrder.ASC)
+
+    assertEquals(SortField.SKU, spec.field, "when sortField is null, field must default to SKU")
+    assertEquals(SortOrder.ASC, spec.order, "order should be preserved")
+  }
+
+  @Test
+  fun `of should use provided sortField when not null`() {
+    val spec = SortSpec.of(SortField.PRICE, SortOrder.DESC)
+
+    assertEquals(SortField.PRICE, spec.field)
+    assertEquals(SortOrder.DESC, spec.order)
+  }
+
+  @Test
+  fun `constructor preserves both field and order`() {
+    val spec = SortSpec(SortField.DESCRIPTION, SortOrder.ASC)
+
+    assertEquals(SortField.DESCRIPTION, spec.field)
+    assertEquals(SortOrder.ASC, spec.order)
+  }
+}

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
@@ -6,8 +6,8 @@ import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.Pric
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
-import com.capitole.capitoleproductcatalogapi.domain.product.SortField
-import com.capitole.capitoleproductcatalogapi.domain.product.SortOrder
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
+import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
 import com.capitole.capitoleproductcatalogapi.infrastructure.advice.GlobalExceptionHandler
 import com.capitole.capitoleproductcatalogapi.infrastructure.controllers.getproductcatalog.GetProductCatalogController
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
@@ -98,7 +98,11 @@ class GetProductCatalogControllerTest {
               finalPrice = "84.00",
               category = Category.ELECTRONICS.toDTO()
           )
-      )
+      ),
+      page = 0,
+      size = 2,
+      totalElements = 2,
+      totalPages = 1
   )
 
   @Test

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
@@ -1,10 +1,10 @@
 package com.capitole.capitoleproductcatalogapi.infrastructure
 
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.DiscountPercentageDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetProductCatalog
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.PriceDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
-import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.DiscountPercentageDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.GetProductCatalog
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.ProductCatalogDTO
+import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.dto.toDTO
 import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField

--- a/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
+++ b/src/test/kotlin/com/capitole/capitoleproductcatalogapi/infrastructure/GetProductCatalogControllerTest.kt
@@ -5,6 +5,7 @@ import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.GetP
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.PriceDTO
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.ProductCatalogDTO
 import com.capitole.capitoleproductcatalogapi.application.getproductcatalog.toDTO
+import com.capitole.capitoleproductcatalogapi.domain.pagination.PageRequest
 import com.capitole.capitoleproductcatalogapi.domain.product.Category
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortField
 import com.capitole.capitoleproductcatalogapi.domain.product.sort.SortOrder
@@ -59,7 +60,14 @@ class GetProductCatalogControllerTest {
               ]
             }
         """.trimIndent()
-    `when`(getProductCatalog.execute(sortField = SortField.PRICE, sortOrder = SortOrder.ASC)).thenReturn(
+
+    `when`(
+        getProductCatalog.execute(
+            sortField = SortField.PRICE,
+            sortOrder = SortOrder.ASC,
+            pageRequest = PageRequest.of(0, 20)
+        )
+    ).thenReturn(
         buildExpectedProductCatalogDTO()
     )
 


### PR DESCRIPTION
## What’s Changed

- **Domain**  
  - Introduced `PageRequest` (page, size) with sensible defaults.  
  - Added `Page<T>` value object carrying `content`, `page`, `size`, `totalElements` and computed `totalPages`.

- **Application & Controller**  
  - Extended `GetProductCatalog.execute(...)` to accept `PageRequest`.  
  - Controller now parses `page` & `size` query parameters and returns paged DTO.

- **Repository Layer**  
  - **SQL-backed** (`PostgresSQLProductRepository`):  
    - `ProductSQLBuilder` now appends `LIMIT`/`OFFSET` and supplies total-count query.  
    - Repository builds both content and count SQL, maps to `Page<Product>`.  
  - **In-memory** (`InMemoryProductRepository`):  
    - Filters, sorts and then slices the full list according to `PageRequest`.

- **Tests**  
  - **Unit**: new `PageRequest` and `Page<T>` tests ensure correct defaulting, bounds and total-page calculation.  
  - **Integration**: updated endpoints to verify pagination metadata (`page`, `size`, `totalElements`, `totalPages`) alongside content.
